### PR TITLE
Run the MetaBase integration tests via ClickHouse

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+  build:
+    docker: # use the docker executor type; machine and macos executors are also supported
+      - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+    steps:
+      - checkout # check out the code in the project directory
+      - run: echo "hello world" # run the `echo` command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ defaults: &defaults
 version: 2.1
 
 jobs:
-  checkout:
+
+  checkout-and-cache:
     docker:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
@@ -21,8 +22,12 @@ jobs:
           # we'll need to touch our project.clj when MetaBase dependencies change
           key: metabase-clickhouse-driver-{{ checksum "metabase-clickhouse-driver/project.clj" }}
       - run:
-          name: Resolving Dependencies
+          name: Resolving Dependencies (MetaBase)
           working_directory: metabase
+          command: lein deps
+      - run:
+          name: Resolving Dependencies (ClickHouse driver)
+          working_directory: metabase-clickhouse-driver
           command: lein deps
       - save_cache:
           paths:
@@ -106,24 +111,40 @@ jobs:
             DRIVERS: h2,clickhouse
         command: lein with-profile +ci test
         no_output_timeout: 5m
-          
+
+  assemble-driver
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Assemble ClickHouse driver
+          working_directory: metabase
+          command: bin/build-driver.sh clickhouse
+          no_output_timeout: 5m
+      - store_artifacts:
+          path: metabase/modules/drivers/clickhouse/target/uberjar/clickhouse.metabase-driver.jar
+
 workflows:
   version: 2
   build:
     jobs:
       - checkout
-      - be-linter-eastwood:
-          requires:
-            - checkout
-      -  be-linter-docstring-checker:
-           requires:
-            - checkout
-      -  be-linter-bikeshed:
-          requires:
-            - checkout
-      - be-linter-reflection-warnings:
-          requires:
-            - checkout
-      - be-tests-clickhouse:
+      # - be-linter-eastwood:
+      #     requires:
+      #       - checkout
+      # -  be-linter-docstring-checker:
+      #      requires:
+      #       - checkout
+      # -  be-linter-bikeshed:
+      #     requires:
+      #       - checkout
+      # - be-linter-reflection-warnings:
+      #     requires:
+      #       - checkout
+      # - be-tests-clickhouse:
+      #     requires:
+      #       - checkout
+      - assemble-driver:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,34 @@
-version: 2
+version: 2.1
+
 jobs:
-  build:
+  checkout:
     docker:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
       - checkout:
           path: metabase-clickhouse-driver
-      - run: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
-      - run: pwd && ls -l
-      
+      - run:
+          name: Check-out MetaBase Integration Branch
+          command: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
+      - run:
+          name: Set up paths
+          command: ln -sf metabase-clickhouse-driver metabase/modules/drivers/clickhouse
+  be-tests:
+    steps:
+      - run:
+          name: Enter MetaBase project
+          command: cd metabase
+      - run:
+          name: Run backend unit tests with Java 8
+          command: lein with-profile +ci test
+          no_output_timeout: 5m
+
+be-linter-eastwood:
+    steps:
+      - run:
+         name: Enter MetaBase project
+         command: cd metabase
+      - run:
+          name: Run Eastwood linter
+          command: lein with-profile +ci eastwood
+          no_output_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,20 +31,19 @@ jobs:
       - run:
           name: Run backend unit tests with Java 8
           working_directory: metabase
-          command: pwd && ls -l
-#          command: lein with-profile +ci test
+          command: ls -l modules/drivers/clickhouse &&lein with-profile +ci test
           no_output_timeout: 5m
 
-  # be-linter-eastwood:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: /home/circleci/
-  #     - run:
-  #         name: Run Eastwood linter
-  #         working_directory: project/metabase
-  #         command: lein with-profile +ci eastwood
-  #         no_output_timeout: 5m
+  be-linter-eastwood:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run Eastwood linter
+          working_directory: metabase
+          command: lein with-profile +ci eastwood
+          no_output_timeout: 5m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,6 @@ workflows:
       - be-tests:
           requires:
             - checkout
-      - be-linter-eastwood:
-          requires:
-            - checkout
+      # - be-linter-eastwood:
+      #     requires:
+      #       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,19 +31,20 @@ jobs:
       - run:
           name: Run backend unit tests with Java 8
           working_directory: project/metabase
-          command: lein with-profile +ci test
+          command: pwd && ls -l
+#          command: lein with-profile +ci test
           no_output_timeout: 5m
 
-  be-linter-eastwood:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run Eastwood linter
-          working_directory: project/metabase
-          command: lein with-profile +ci eastwood
-          no_output_timeout: 5m
+  # be-linter-eastwood:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - run:
+  #         name: Run Eastwood linter
+  #         working_directory: project/metabase
+  #         command: lein with-profile +ci eastwood
+  #         no_output_timeout: 5m
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,19 +88,6 @@ jobs:
           command: lein bikeshed
           no_output_timeout: 5m
 
-  linter-reflection-warnings:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run reflection warnings checker
-          working_directory: metabase-clickhouse-driver
-          environment:
-            DRIVERS: h2,clickhouse
-          command: ./bin/reflection-linter
-          no_output_timeout: 5m
-
   tests-clickhouse:
     docker:
     - image: circleci/clojure:lein-2.8.1-node-browsers
@@ -143,9 +130,6 @@ workflows:
            requires:
             - checkout
       - linter-bikeshed:
-          requires:
-            - checkout
-      - linter-reflection-warnings:
           requires:
             - checkout
       - tests-clickhouse:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,8 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci/
           paths:
-            - metabase-clickhouse-driver
-            - metabase
+            - project/metabase-clickhouse-driver
+            - project/metabase
           
   be-tests:
     <<: *defaults
@@ -30,7 +30,7 @@ jobs:
           at: /home/circleci/
       - run:
           name: Run backend unit tests with Java 8
-          working_directory: metabase
+          working_directory: project/metabase
           command: lein with-profile +ci test
           no_output_timeout: 5m
 
@@ -41,7 +41,7 @@ jobs:
           at: /home/circleci/
       - run:
           name: Run Eastwood linter
-          working_directory: metabase
+          working_directory: project/metabase
           command: lein with-profile +ci eastwood
           no_output_timeout: 5m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           at: /home/circleci/
       - run:
           name: Run backend unit tests with Java 8
-          working_directory: project/metabase
+          working_directory: metabase
           command: pwd && ls -l
 #          command: lein with-profile +ci test
           no_output_timeout: 5m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Building and Installing MetaBase
           working_directory: metabase
-          command: lein install-for-building-
+          command: lein install-for-building-drivers
       - run:
           name: Resolving Dependencies (ClickHouse driver)
           working_directory: metabase-clickhouse-driver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,21 +130,21 @@ workflows:
   build:
     jobs:
       - checkout
-      # - be-linter-eastwood:
-      #     requires:
-      #       - checkout
-      # -  be-linter-docstring-checker:
-      #      requires:
-      #       - checkout
-      # -  be-linter-bikeshed:
-      #     requires:
-      #       - checkout
-      # - be-linter-reflection-warnings:
-      #     requires:
-      #       - checkout
-      # - be-tests-clickhouse:
-      #     requires:
-      #       - checkout
+      - be-linter-eastwood:
+          requires:
+            - checkout
+      -  be-linter-docstring-checker:
+           requires:
+            - checkout
+      -  be-linter-bikeshed:
+          requires:
+            - checkout
+      - be-linter-reflection-warnings:
+          requires:
+            - checkout
+      - be-tests-clickhouse:
+          requires:
+            - checkout
       - assemble-driver:
           requires:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,66 +40,66 @@ jobs:
             - project/metabase
             - .m2
           
-  be-linter-eastwood:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run Eastwood linter
-          working_directory: metabase
-          environment:
-            DRIVERS: h2,clickhouse
-          command: lein with-profile +ci eastwood
-          no_output_timeout: 5m
+  # linter-eastwood:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - run:
+  #         name: Run Eastwood linter
+  #         working_directory: metabase-clickhouse-driver
+  #         environment:
+  #           DRIVERS: h2,clickhouse
+  #         command: lein with-profile +ci eastwood
+  #         no_output_timeout: 5m
 
-  be-linter-docstring-checker:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run dockstring-checker
-          working_directory: metabase
-          command: lein with-profile +ci docstring-checker
-          no_output_timeout: 5m
+  # linter-docstring-checker:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - run:
+  #         name: Run dockstring-checker
+  #         working_directory: metabase-clickhouse-driver
+  #         command: lein with-profile +ci docstring-checker
+  #         no_output_timeout: 5m
 
-  be-linter-namespace-decls:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run namespace decl checker
-          working_directory: metabase
-          command: lein with-profile +ci check-namespace-decls
-          no_output_timeout: 5m
+  # linter-namespace-decls:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - run:
+  #         name: Run namespace decl checker
+  #         working_directory: metabase-clickhouse-driver
+  #         command: lein with-profile +ci check-namespace-decls
+  #         no_output_timeout: 5m
 
-  be-linter-bikeshed:
+  linter-bikeshed:
     <<: *defaults
     steps:
       - attach_workspace:
           at: /home/circleci/
       - run:
           name: Run Bikeshed linter
-          working_directory: metabase
+          working_directory: metabase-clickhouse-driver
           environment:
             DRIVERS: h2,clickhouse
-          command: lein with-profile +ci bikeshed
+          command: lein bikeshed
           no_output_timeout: 5m
 
-  be-linter-reflection-warnings:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run reflection warnings checker
-          working_directory: metabase
-          environment:
-            DRIVERS: h2,clickhouse
-          command: ./bin/reflection-linter
-          no_output_timeout: 5m
+  # linter-reflection-warnings:
+  #   <<: *defaults
+  #   steps:
+  #     - attach_workspace:
+  #         at: /home/circleci/
+  #     - run:
+  #         name: Run reflection warnings checker
+  #         working_directory: metabase-clickhouse-driver
+  #         environment:
+  #           DRIVERS: h2,clickhouse
+  #         command: ./bin/reflection-linter
+  #         no_output_timeout: 5m
 
   be-tests-clickhouse:
     docker:
@@ -136,21 +136,21 @@ workflows:
   build:
     jobs:
       - checkout
-      - be-linter-eastwood:
+      # - be-linter-eastwood:
+      #     requires:
+      #       - checkout
+      # -  be-linter-docstring-checker:
+      #      requires:
+      #       - checkout
+      -  linter-bikeshed:
           requires:
             - checkout
-      -  be-linter-docstring-checker:
-           requires:
-            - checkout
-      -  be-linter-bikeshed:
-          requires:
-            - checkout
-      - be-linter-reflection-warnings:
-          requires:
-            - checkout
-      - be-tests-clickhouse:
-          requires:
-            - checkout
-      - assemble-driver:
-          requires:
-            - checkout
+      # - be-linter-reflection-warnings:
+      #     requires:
+      #       - checkout
+      # - be-tests-clickhouse:
+      #     requires:
+      #       - checkout
+      # - assemble-driver:
+      #     requires:
+      #       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ jobs:
     docker:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
-      - checkout
-      - run: echo "hello world"
-      - run: git clone --depth=1 git@github.com:enqueue/metabase.git
+      - checkout metabase-clickhouse-driver
+      - run: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
       - run: pwd && ls -l
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
 version: 2
 jobs:
   build:
-    docker: # use the docker executor type; machine and macos executors are also supported
-      - image: circleci/node:4.8.2 # the primary container, where your job's commands are run
+    docker:
+      - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
-      - checkout # check out the code in the project directory
-      - run: echo "hello world" # run the `echo` command
+      - checkout
+      - run: echo "hello world"
+      - run: git clone --depth=1 git@github.com:enqueue/metabase.git
+      - run: pwd && ls -l
+      

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
       - run:
           name: Set up paths
-          command: ln -sfv ./metabase-clickhouse-driver metabase/modules/drivers/clickhouse
+          command: ln -sfv ../../../metabase-clickhouse-driver metabase/modules/drivers/clickhouse
       - persist_to_workspace:
           root: /home/circleci/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,28 +17,33 @@ jobs:
       - run:
           name: Set up paths
           command: ln -sf metabase-clickhouse-driver metabase/modules/drivers/clickhouse
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - metabase-clickhouse-driver
+            - metabase
+          
   be-tests:
     <<: *defaults
     steps:
-      - run:
-          name: Enter MetaBase project
-          command: cd metabase
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run backend unit tests with Java 8
+          working_directory: metabase
           command: lein with-profile +ci test
           no_output_timeout: 5m
 
   be-linter-eastwood:
     <<: *defaults
     steps:
-      - run:
-         name: Enter MetaBase project
-         command: cd metabase
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run Eastwood linter
+          working_directory: metabase
           command: lein with-profile +ci eastwood
           no_output_timeout: 5m
-
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
       - checkout:
-        path: metabase-clickhouse-driver
+          path: metabase-clickhouse-driver
       - run: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
       - run: pwd && ls -l
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,23 @@ jobs:
       - run:
           name: Set up paths
           command: ln -sfv ../../../metabase-clickhouse-driver metabase/modules/drivers/clickhouse
+      - restore_cache:
+          # we'll need to touch our project.clj when MetaBase dependencies change
+          key: metabase-clickhouse-driver-{{ checksum "metabase-clickhouse-driver/project.clj" }}
+      - run:
+          name: Resolving Dependencies
+          working_directory: metabase
+          command: lein deps
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: metabase-clickhouse-driver-{{ checksum "metabase-clickhouse-driver/project.clj" }}
       - persist_to_workspace:
           root: /home/circleci/
           paths:
             - project/metabase-clickhouse-driver
             - project/metabase
+            - ~/.m2
           
   be-linter-eastwood:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+defaults: &defaults
+  docker:
+    - image: circleci/clojure:lein-2.8.1-node-browsers
+
 version: 2.1
 
 jobs:
@@ -14,6 +18,7 @@ jobs:
           name: Set up paths
           command: ln -sf metabase-clickhouse-driver metabase/modules/drivers/clickhouse
   be-tests:
+    <<: *defaults
     steps:
       - run:
           name: Enter MetaBase project
@@ -24,6 +29,7 @@ jobs:
           no_output_timeout: 5m
 
 be-linter-eastwood:
+    <<: *defaults
     steps:
       - run:
          name: Enter MetaBase project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,24 +16,13 @@ jobs:
           command: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
       - run:
           name: Set up paths
-          command: ln -sf metabase-clickhouse-driver metabase/modules/drivers/clickhouse
+          command: ln -sfv ./metabase-clickhouse-driver metabase/modules/drivers/clickhouse
       - persist_to_workspace:
           root: /home/circleci/
           paths:
             - project/metabase-clickhouse-driver
             - project/metabase
           
-  be-tests:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run backend unit tests with Java 8
-          working_directory: metabase
-          command: ls -l modules/drivers/clickhouse &&lein with-profile +ci test
-          no_output_timeout: 5m
-
   be-linter-eastwood:
     <<: *defaults
     steps:
@@ -45,14 +34,84 @@ jobs:
           command: lein with-profile +ci eastwood
           no_output_timeout: 5m
 
+  be-linter-docstring-checker:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run dockstring-checker
+          working_directory: metabase
+          command: lein with-profile +ci docstring-checker
+          no_output_timeout: 5m
+
+  be-linter-namespace-decls:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run namespace decl checker
+          working_directory: metabase
+          command: lein with-profile +ci check-namespace-decls
+          no_output_timeout: 5m
+
+  be-linter-bikeshed:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run Bikeshed linter
+          working_directory: metabase
+          command: lein with-profile +ci bikeshed
+          no_output_timeout: 5m
+
+  be-linter-reflection-warnings:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run reflection warnings checker
+          working_directory: metabase
+          command: ./bin/reflection-linter
+          no_output_timeout: 5m
+
+  be-tests-clickhouse:
+    docker:
+    - image: circleci/clojure:lein-2.8.1-node-browsers
+    - image: yandex/clickhouse-server:latest
+      environment:
+        TZ: "/usr/share/zoneinfo/UTC"
+    steps:
+    - attach_workspace:
+        at: /home/circleci/
+    - run:
+        name: Run backend unit tests (ClickHouse)
+        working_directory: metabase
+        environment:
+            DRIVERS: h2,clickhouse
+        command: lein with-profile +ci test
+        no_output_timeout: 5m
+          
 workflows:
   version: 2
   build:
     jobs:
       - checkout
-      - be-tests:
+      - be-linter-eastwood:
           requires:
             - checkout
-      # - be-linter-eastwood:
-      #     requires:
-      #       - checkout
+      -  be-linter-docstring-checker:
+           requires:
+            - checkout
+      -  be-linter-bikeshed:
+          requires:
+            - checkout
+      - be-linter-reflection-warnings:
+          requires:
+            - checkout
+      - be-tests-clickhouse:
+          requires:
+            - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ jobs:
     docker:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:
-      - checkout metabase-clickhouse-driver
+      - checkout:
+        path: metabase-clickhouse-driver
       - run: git clone --depth=1 -b $MB_BRANCH $MB_REPO metabase
       - run: pwd && ls -l
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,9 @@ jobs:
           # we'll need to touch our project.clj when MetaBase dependencies change
           key: metabase-clickhouse-driver-{{ checksum "metabase-clickhouse-driver/project.clj" }}
       - run:
-          name: Resolving Dependencies (MetaBase)
+          name: Building and Installing MetaBase
           working_directory: metabase
-          command: lein deps
+          command: lein install-for-building-
       - run:
           name: Resolving Dependencies (ClickHouse driver)
           working_directory: metabase-clickhouse-driver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
         command: lein with-profile +ci test
         no_output_timeout: 5m
 
-  assemble-driver
+  assemble-driver:
     <<: *defaults
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       - run:
           name: Run Eastwood linter
           working_directory: metabase
+          environment:
+            DRIVERS: h2,clickhouse
           command: lein with-profile +ci eastwood
           no_output_timeout: 5m
 
@@ -81,6 +83,8 @@ jobs:
       - run:
           name: Run Bikeshed linter
           working_directory: metabase
+          environment:
+            DRIVERS: h2,clickhouse
           command: lein with-profile +ci bikeshed
           no_output_timeout: 5m
 
@@ -92,6 +96,8 @@ jobs:
       - run:
           name: Run reflection warnings checker
           working_directory: metabase
+          environment:
+            DRIVERS: h2,clickhouse
           command: ./bin/reflection-linter
           no_output_timeout: 5m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,9 @@ workflows:
   build:
     jobs:
       - checkout
-      - be-tests
-      - be-linter-eastwood
+      - be-tests:
+          requires:
+            - checkout
+      - be-linter-eastwood:
+          requires:
+            - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           paths:
             - project/metabase-clickhouse-driver
             - project/metabase
-            - ~/.m2
+            - .m2
           
   be-linter-eastwood:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: lein with-profile +ci test
           no_output_timeout: 5m
 
-be-linter-eastwood:
+  be-linter-eastwood:
     <<: *defaults
     steps:
       - run:
@@ -38,3 +38,12 @@ be-linter-eastwood:
           name: Run Eastwood linter
           command: lein with-profile +ci eastwood
           no_output_timeout: 5m
+
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - checkout
+      - be-tests
+      - be-linter-eastwood

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 
 jobs:
 
-  checkout-and-cache:
+  checkout:
     docker:
       - image: circleci/clojure:lein-2.8.1-node-browsers
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,29 +40,29 @@ jobs:
             - project/metabase
             - .m2
           
-  # linter-eastwood:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: /home/circleci/
-  #     - run:
-  #         name: Run Eastwood linter
-  #         working_directory: metabase-clickhouse-driver
-  #         environment:
-  #           DRIVERS: h2,clickhouse
-  #         command: lein with-profile +ci eastwood
-  #         no_output_timeout: 5m
+  linter-eastwood:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run Eastwood linter
+          working_directory: metabase-clickhouse-driver
+          environment:
+            DRIVERS: h2,clickhouse
+          command: lein with-profile +ci eastwood
+          no_output_timeout: 5m
 
-  # linter-docstring-checker:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: /home/circleci/
-  #     - run:
-  #         name: Run dockstring-checker
-  #         working_directory: metabase-clickhouse-driver
-  #         command: lein with-profile +ci docstring-checker
-  #         no_output_timeout: 5m
+  linter-docstring-checker:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run dockstring-checker
+          working_directory: metabase-clickhouse-driver
+          command: lein with-profile +ci docstring-checker
+          no_output_timeout: 5m
 
   # linter-namespace-decls:
   #   <<: *defaults
@@ -88,20 +88,20 @@ jobs:
           command: lein bikeshed
           no_output_timeout: 5m
 
-  # linter-reflection-warnings:
-  #   <<: *defaults
-  #   steps:
-  #     - attach_workspace:
-  #         at: /home/circleci/
-  #     - run:
-  #         name: Run reflection warnings checker
-  #         working_directory: metabase-clickhouse-driver
-  #         environment:
-  #           DRIVERS: h2,clickhouse
-  #         command: ./bin/reflection-linter
-  #         no_output_timeout: 5m
+  linter-reflection-warnings:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          name: Run reflection warnings checker
+          working_directory: metabase-clickhouse-driver
+          environment:
+            DRIVERS: h2,clickhouse
+          command: ./bin/reflection-linter
+          no_output_timeout: 5m
 
-  be-tests-clickhouse:
+  tests-clickhouse:
     docker:
     - image: circleci/clojure:lein-2.8.1-node-browsers
     - image: yandex/clickhouse-server:latest
@@ -136,21 +136,21 @@ workflows:
   build:
     jobs:
       - checkout
-      # - be-linter-eastwood:
-      #     requires:
-      #       - checkout
-      # -  be-linter-docstring-checker:
-      #      requires:
-      #       - checkout
-      -  linter-bikeshed:
+      - linter-eastwood:
           requires:
             - checkout
-      # - be-linter-reflection-warnings:
-      #     requires:
-      #       - checkout
-      # - be-tests-clickhouse:
-      #     requires:
-      #       - checkout
-      # - assemble-driver:
-      #     requires:
-      #       - checkout
+      - linter-docstring-checker:
+           requires:
+            - checkout
+      - linter-bikeshed:
+          requires:
+            - checkout
+      - linter-reflection-warnings:
+          requires:
+            - checkout
+      - tests-clickhouse:
+          requires:
+            - checkout
+      - assemble-driver:
+          requires:
+            - checkout

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,12 @@
   :min-lein-version "2.5.0"
 
   :aliases
-  {"bikeshed" ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]}
+  {"bikeshed"                  ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]
+   "check-namespace-decls"     ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
+   "check-reflection-warnings" ["with-profile" "+reflection-warnings" "check"]
+   "docstring-checker"         ["with-profile" "+docstring-checker" "docstring-checker"]
+   "eastwood"                  ["with-profile" "+eastwood" "eastwood"]
+   "test"                      ["with-profile" "+expectations" "expectations"]}
   
   :dependencies
   [[ru.yandex.clickhouse/clickhouse-jdbc "0.1.52"
@@ -21,6 +26,39 @@
     :target-path   "target/%s"
     :uberjar-name  "clickhouse.metabase-driver.jar"}
 
-  :bikeshed
-    {:plugins [[lein-bikeshed "0.4.1"]]}})
+   :bikeshed
+   {:plugins [[lein-bikeshed "0.4.1"]]}
+   
+   :eastwood
+   {:plugins
+    [[jonase/eastwood "0.3.1" :exclusions [org.clojure/clojure]]]
+    
+    :eastwood
+    {:exclude-namespaces [:test-paths]
+     :config-files       ["../metabase/test_resources/eastwood-config.clj"]
+     :add-linters        [:unused-private-vars
+                          :unused-namespaces
+                          ;; These linters are pretty useful but give a few false positives and can't be selectively
+                          ;; disabled (yet)
+                          ;;
+                          ;; For example see https://github.com/jonase/eastwood/issues/193
+                                        ;
+                          ;; It's still useful to re-enable them and run them every once in a while because they catch
+                          ;; a lot of actual errors too. Keep an eye on the issue above and re-enable them if we can
+                          ;; get them to work
+                          #_:unused-fn-args
+                          #_:unused-locals]
+     ;; Turn this off temporarily until we finish removing self-deprecated functions & macros
+     :exclude-linters    [:deprecations]}}
 
+   :reflection-warnings
+   {:global-vars {*warn-on-reflection* true}}
+
+   :docstring-checker
+   {:plugins
+    [[docstring-checker "1.0.3"]]
+    
+    :docstring-checker
+    {:include [#"^metabase"]
+     :exclude [#"test"
+               #"^metabase\.http-client$"]}}})

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,9 @@
 (defproject metabase/clickhouse-driver "1.0.0-SNAPSHOT-0.1.52"
   :min-lein-version "2.5.0"
 
+  :aliases
+  {"bikeshed" ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]}
+  
   :dependencies
   [[ru.yandex.clickhouse/clickhouse-jdbc "0.1.52"
     :exclusions [com.fasterxml.jackson.core/jackson-core

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,6 @@
   :aliases
   {"bikeshed"                  ["with-profile" "+bikeshed" "bikeshed" "--max-line-length" "205"]
    "check-namespace-decls"     ["with-profile" "+check-namespace-decls" "check-namespace-decls"]
-   "check-reflection-warnings" ["with-profile" "+reflection-warnings" "check"]
    "docstring-checker"         ["with-profile" "+docstring-checker" "docstring-checker"]
    "eastwood"                  ["with-profile" "+eastwood" "eastwood"]
    "test"                      ["with-profile" "+expectations" "expectations"]}
@@ -50,9 +49,6 @@
                           #_:unused-locals]
      ;; Turn this off temporarily until we finish removing self-deprecated functions & macros
      :exclude-linters    [:deprecations]}}
-
-   :reflection-warnings
-   {:global-vars {*warn-on-reflection* true}}
 
    :docstring-checker
    {:plugins

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject metabase/clickhouse-driver "1.0.0-SNAPSHOT-0.1.48"
+(defproject metabase/clickhouse-driver "1.0.0-SNAPSHOT-0.1.52"
   :min-lein-version "2.5.0"
 
   :dependencies
-  [[ru.yandex.clickhouse/clickhouse-jdbc "0.1.50"
+  [[ru.yandex.clickhouse/clickhouse-jdbc "0.1.52"
     :exclusions [com.fasterxml.jackson.core/jackson-core
                  org.slf4j/slf4j-api]]]
 

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  org.slf4j/slf4j-api]]]
 
   :profiles
+
   {:provided
    {:dependencies [[metabase-core "1.0.0-SNAPSHOT"]]}
 
@@ -15,4 +16,8 @@
     :aot           :all
     :javac-options ["-target" "1.8", "-source" "1.8"]
     :target-path   "target/%s"
-    :uberjar-name  "clickhouse.metabase-driver.jar"}})
+    :uberjar-name  "clickhouse.metabase-driver.jar"}
+
+  :bikeshed
+    {:plugins [[lein-bikeshed "0.4.1"]]}})
+

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -4,7 +4,6 @@
             [clojure.string :as string]
             [honeysql.core :as hsql]
             [metabase
-             [config :as config]
              [driver :as driver]
              [util :as u]]
             [metabase.driver

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.driver.clickhouse-test
   "Tests for specific behavior of the ClickHouse driver."
-  (:require [expectations :refer :all]
+  (:require [expectations :refer [expect]]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.util :as u]
             [metabase.query-processor-test :refer :all]


### PR DESCRIPTION
Fixes issue #3 

There are probably more elegant ways to do this, but this is how it works:

* Check-out branch `clickhouse-driver-testing` from enqueue metabase fork
* Mount clickhouse driver directory beneath `modules/drivers`
* Run backend integration tests for `DRIVERS=h2,clickhouse`