### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ADD https://github.com/enqueue/metabase-clickhouse-driver/releases/download/v0.1
 Assemble
 
 ```
-docker build -f Dockerfile-clickhouse -t foo/metabase-with-clickhouse
+docker build -f Dockerfile-clickhouse -t foo/metabase-with-clickhouse .
 ```
 
 Run


### PR DESCRIPTION
[fix]error msg:"docker build" requires exactly 1 argument(s).