### PR TITLE
JDBC driver upgrade

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {ru.yandex.clickhouse/clickhouse-jdbc {:mvn/version "0.3.1"}}}
+ {com.clickhouse/clickhouse-jdbc {:mvn/version "0.3.2-patch11"}}}

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 0.8.1
+  version: 0.8.2
   description: Allows Metabase to connect to ClickHouse databases.
 driver:
   name: clickhouse

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -26,4 +26,4 @@ init:
   - step: load-namespace
     namespace: metabase.driver.clickhouse
   - step: register-jdbc-driver
-    class: ru.yandex.clickhouse.ClickHouseDriver
+    class: com.clickhouse.jdbc.ClickHouseDriver

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -16,8 +16,7 @@
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
             [metabase.util.honeysql-extensions :as hx]
-            [schema.core :as s]
-            [metabase.pulse.render.table :as table])
+            [schema.core :as s])
   (:import [java.sql
             DatabaseMetaData
             ResultSet

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -77,7 +77,7 @@
     {user "default" password "" dbname "default" host "localhost" port "8123"}
     :as details}]
   (->
-   {:classname "ru.yandex.clickhouse.ClickHouseDriver"
+   {:classname "com.clickhouse.jdbc.ClickHouseDriver"
     :subprotocol "clickhouse"
     :subname (str "//" host ":" port "/" dbname)
     :password password

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -66,10 +66,8 @@
   (database-type->base-type (str/replace (name database-type)
                                          #"(?:Nullable|LowCardinality)\((\S+)\)"
                                          "$1")))
-
-(defmethod sql-jdbc.sync/excluded-schemas :clickhouse
-  [_]
-  #{"system" "information_schema" "INFORMATION_SCHEMA"})
+(def ^:private excluded-schemas #{"system" "information_schema" "INFORMATION_SCHEMA"})
+(defmethod sql-jdbc.sync/excluded-schemas :clickhouse [_] excluded-schemas)
 
 (defmethod sql-jdbc.conn/connection-details->spec :clickhouse
   [_
@@ -470,8 +468,7 @@
 
 (defn- is-not-excluded-schema
   [table-schem]
-  (let [excluded-schemas (sql-jdbc.sync/excluded-schemas :clickhouse)]
-    (not (contains? excluded-schemas (:table_schem table-schem)))))
+  (not (contains? excluded-schemas (:table_schem table-schem))))
 
 (defn- post-filtered-active-tables
   [driver ^DatabaseMetaData metadata & [db-name-or-nil]]

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -262,7 +262,7 @@
 
 
 (deftest clickhouse-basic-connection-string
-  (is (= {:classname "ru.yandex.clickhouse.ClickHouseDriver"
+  (is (= {:classname "com.clickhouse.jdbc.ClickHouseDriver"
           :subprotocol "clickhouse"
           :subname "//localhost:8123/foo?sessionTimeout=42"
           :user "default"


### PR DESCRIPTION
Branched off #106 
We now use the latest ClickHouse JDBC driver.
The table metadata lookup was updated there and I slightly refactored the related driver methods.
