### PR TITLE
Add default-advanced-options plugin feature and JDBC additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Metabase Release | Driver Version
 0.41.2           | 0.8.0
 0.41.3.1         | 0.8.1
 0.42.x           | 0.8.1
-0.44             | 0.8.2
+0.44.x           | 0.8.3
 
 ### Building from Source
 

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -21,7 +21,7 @@ driver:
     - advanced-options-start
     - merge:
         - additional-options
-        - placeholder: "max_rows_to_group_by=42"
+        - placeholder: "connection_timeout=1000&max_rows_to_group_by=42"
     - default-advanced-options
   connection-properties-include-tunnel-config: true
 init:

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,6 +1,6 @@
 info:
   name: Metabase ClickHouse Driver
-  version: 0.8.2
+  version: 0.8.3
   description: Allows Metabase to connect to ClickHouse databases.
 driver:
   name: clickhouse

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -18,9 +18,11 @@ driver:
     - user
     - password
     - ssl
+    - advanced-options-start
     - merge:
         - additional-options
         - placeholder: "max_rows_to_group_by=42"
+    - default-advanced-options
   connection-properties-include-tunnel-config: true
 init:
   - step: load-namespace

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -56,6 +56,22 @@
            last
            double)))))
 
+(deftest clickhouse-large-decimal64
+  (mt/test-driver
+   :clickhouse
+   (let [[d1 d2] ["12345123.123456789", "78.245"]
+         query-result (data/dataset
+                       (tx/dataset-definition "metabase_tests_decimal"
+                                              ["test-data-large-decimal64"
+                                               [{:field-name "my_money"
+                                                 :base-type {:native "Decimal(18,10)"}}]
+                                               [[d1] [d2]]])
+                       (data/run-mbql-query test-data-large-decimal64 {}))
+         rows (qp.test/rows query-result)
+         result (map last rows)]
+     (println rows)
+     (is (= [(bigdec d1) (bigdec d2)] result)))))
+
 (deftest clickhouse-array-string
   (mt/test-driver
    :clickhouse

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -69,7 +69,6 @@
                        (data/run-mbql-query test-data-large-decimal64 {}))
          rows (qp.test/rows query-result)
          result (map last rows)]
-     (println rows)
      (is (= [(bigdec d1) (bigdec d2)] result)))))
 
 (deftest clickhouse-array-string

--- a/test/metabase/driver/clickhouse_test.clj
+++ b/test/metabase/driver/clickhouse_test.clj
@@ -56,21 +56,6 @@
            last
            double)))))
 
-(deftest clickhouse-large-decimal64
-  (mt/test-driver
-   :clickhouse
-   (let [[d1 d2] ["12345123.123456789", "78.245"]
-         query-result (data/dataset
-                       (tx/dataset-definition "metabase_tests_decimal"
-                                              ["test-data-large-decimal64"
-                                               [{:field-name "my_money"
-                                                 :base-type {:native "Decimal(18,10)"}}]
-                                               [[d1] [d2]]])
-                       (data/run-mbql-query test-data-large-decimal64 {}))
-         rows (qp.test/rows query-result)
-         result (map last rows)]
-     (is (= [(bigdec d1) (bigdec d2)] result)))))
-
 (deftest clickhouse-array-string
   (mt/test-driver
    :clickhouse


### PR DESCRIPTION
Adds Metabase's `default-advanced-options` plugin feature.
Among other things, it allows users to sync their databases daily instead of hourly.

This also brings back the JDBC connection's "additional-options", which were previously missing in the UI, and resolves https://github.com/enqueue/metabase-clickhouse-driver/issues/85.

![image](https://user-images.githubusercontent.com/3175289/204867299-230f0092-bbf4-4f7a-9bd8-94f39cd28b5b.png)