### PR TITLE
Remove Booleans workaround

### DIFF
--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -37,6 +37,7 @@
 (def ^:private database-type->base-type
   (sql-jdbc.sync/pattern-based-database-type->base-type
    [[#"Array" :type/Array]
+    [#"Boolean" :type/Boolean]
     [#"DateTime" :type/DateTime]
     [#"DateTime64" :type/DateTime]
     [#"Date" :type/Date]
@@ -220,14 +221,6 @@
   [_ t]
   (format "'%s'" (t/format "yyyy-MM-dd HH:mm:ss.SSSZZZZZ" t)))
 
-;; ClickHouse doesn't support `TRUE`/`FALSE`; it uses `1`/`0`, respectively;
-;; convert these booleans to UInt8
-(defmethod sql.qp/->honeysql [:clickhouse Boolean] [_ bool] (if bool 1 0))
-
-(defmethod sql/->prepared-substitution [:clickhouse Boolean]
-  [driver bool]
-  (sql/->prepared-substitution driver (if bool 1 0)))
-
 ;; Metabase supplies parameters for Date fields as ZonedDateTime
 ;; ClickHouse complains about too long parameter values. This is unfortunate
 ;; because it eats some performance, but I do not know a better solution
@@ -259,8 +252,8 @@
                                           (.toLocalTime t))
                                          (.getOffset t))))
 
-;; We still need this for the tests that use multiple case statements where 
-;; we can have either Int or Float in different branches, 
+;; We still need this for the tests that use multiple case statements where
+;; we can have either Int or Float in different branches,
 ;; so we just coerce everything to Float64.
 ;;
 ;; See metabase.query-processor-test.expressions-test "Can use expressions as values"
@@ -456,7 +449,7 @@
                "MATERIALIZED VIEW" "MEMORY TABLE" "LOG TABLE"]))
 
 (defn- get-tables
-  "Fetch a JDBC Metadata ResultSet of tables in the DB, 
+  "Fetch a JDBC Metadata ResultSet of tables in the DB,
    optionally limited to ones belonging to a given schema."
   [^DatabaseMetaData metadata ^String schema-or-nil]
   (vec (jdbc/metadata-result
@@ -487,7 +480,7 @@
     (sql-jdbc.conn/db->pooled-connection-spec db-or-id-or-spec)
     db-or-id-or-spec))
 
-;; Strangely enough, the tests only work with :db keyword, 
+;; Strangely enough, the tests only work with :db keyword,
 ;; but the actual sync from the UI uses :dbname
 (defn- get-db-name
   [db-or-id-or-spec]

--- a/test/metabase/test/data/clickhouse.clj
+++ b/test/metabase/test/data/clickhouse.clj
@@ -13,8 +13,8 @@
 
 (sql-jdbc.tx/add-test-extensions! :clickhouse)
 
+(defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "Boolean")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/BigInteger] [_ _] "Int64")
-(defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Boolean]    [_ _] "UInt8")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Char]       [_ _] "String")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/Date]       [_ _] "Date")
 (defmethod sql.tx/field-base-type->sql-type [:clickhouse :type/DateTime]   [_ _] "DateTime64")


### PR DESCRIPTION
Resolves #88 
This workaround is not required anymore with the new JDBC driver.