### PR TITLE
Fix TIMESTAMP_WITH_TIMEZONE behavior, add Metabase Docker container

### DIFF
--- a/.docker/config.xml
+++ b/.docker/config.xml
@@ -14,6 +14,7 @@
   <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
   <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
   <access_control_path>/var/lib/clickhouse/access/</access_control_path>
+  <timezone>UTC</timezone>
 
   <logger>
     <level>debug</level>

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: metabase/metabase
           ref: v0.44.6
-          
+
       - name: Checkout Driver Repo
         uses: actions/checkout@v2
         with:
@@ -31,10 +31,11 @@ jobs:
           java-version: "17"
 
       - name: Start ClickHouse in Docker
-        uses: isbang/compose-action@v1.4.0
+        uses: isbang/compose-action@v1.4.1
         with:
           compose-file: "modules/drivers/clickhouse/docker-compose.yml"
           down-flags: "--volumes"
+          services: "clickhouse"
 
       - name: Install Clojure CLI
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ yarn && yarn build-static-viz
 * Start ClickHouse as a Docker container
 
 ```bash
-docker compose -f modules/drivers/clickhouse/docker-compose.yml up -d
+docker compose -f modules/drivers/clickhouse/docker-compose.yml up -d clickhouse
 ```
 
 Now, you should be able to run the tests:
@@ -107,3 +107,11 @@ bin/build-driver.sh clickhouse
 ```
 
 As the result, `resources/modules/clickhouse.metabase-driver.jar` should be created.
+
+For smoke testing, there is a Metabase with the link to the driver available as a Docker container:
+
+```bash
+docker compose -f modules/drivers/clickhouse/docker-compose.yml up -d metabase
+```
+
+It should pick up the driver jar as a volume.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Metabase Release | Driver Version
 0.41.2           | 0.8.0
 0.41.3.1         | 0.8.1
 0.42.x           | 0.8.1
-0.44.x           | 0.8.3
+0.44.x           | 0.9.0
 
 ## Creating a Metabase Docker image with ClickHouse driver
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,11 @@ services:
     volumes:
       - './.docker/config.xml:/etc/clickhouse-server/config.xml'
       - './.docker/users.xml:/etc/clickhouse-server/users.xml'
+
+  metabase:
+    image: metabase/metabase:v0.44.6
+    container_name: metabase-with-clickhouse-driver
+    ports:
+      - '3000:3000'
+    volumes:
+      - '../../../resources/modules/clickhouse.metabase-driver.jar:/plugins/clickhouse.jar'

--- a/src/metabase/driver/clickhouse.clj
+++ b/src/metabase/driver/clickhouse.clj
@@ -7,7 +7,6 @@
             [java-time :as t]
             [metabase [config :as config] [driver :as driver] [util :as u]]
             [metabase.driver.ddl.interface :as ddl.i]
-            [metabase.driver.sql :as sql]
             [metabase.driver.sql-jdbc [common :as sql-jdbc.common]
              [connection :as sql-jdbc.conn] [execute :as sql-jdbc.execute]
              [sync :as sql-jdbc.sync]]
@@ -15,6 +14,7 @@
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
+            [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]
             [schema.core :as s])
   (:import [java.sql
@@ -430,6 +430,12 @@
       (cond (nil? r) nil
             (= (.toLocalDate r) (t/local-date 1970 1 1)) (.toLocalTime r)
             :else r))))
+
+(defmethod sql-jdbc.execute/read-column-thunk [:clickhouse Types/TIMESTAMP_WITH_TIMEZONE]
+  [_ ^ResultSet rs _ ^Integer i]
+  (fn []
+    (when-let [s (.getString rs i)]
+      (u.date/parse s))))
 
 (defmethod sql-jdbc.execute/read-column-thunk [:clickhouse Types/TIME]
   [_ ^ResultSet rs ^ResultSetMetaData _ ^Integer i]


### PR DESCRIPTION
* Fixed `now()` vs `now(TIMEZONE)` behavior. Should resolve #103 and #81 

![image](https://user-images.githubusercontent.com/3175289/205944011-e56ad33d-b6c8-4026-a967-2401f7d6fab7.png)

* Added Metabase container. It is useful for smoke testing, as we can avoid raw `docker run ...` commands and have a link to the local ClickHouse container without `dockerhost` shenanigans.